### PR TITLE
swap dosyalarının kontrolü

### DIFF
--- a/src/Muhafiz.php
+++ b/src/Muhafiz.php
@@ -85,7 +85,7 @@ class Muhafiz
      */
     public function run($files)
     {
-        $activeRunnersConfig = Git::getConfig("muhafiz.active-runners", "php, phpcs, jshint, lineend, bom");
+        $activeRunnersConfig = Git::getConfig("muhafiz.active-runners", "php, phpcs, jshint, lineend, bom, swap");
         $activeRunners = explode(",", $activeRunnersConfig);
 
         foreach ($activeRunners as $activeRunner) {

--- a/src/Runners/Swap.php
+++ b/src/Runners/Swap.php
@@ -1,0 +1,43 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Muhafiz\Runners;
+use Muhafiz\Utils\System as Sys;
+use Muhafiz\Runners\RunnersAbstract as RunnersAbstract;
+
+/**
+ * Check file for Byte Order Mark
+ */
+class Swap extends RunnersAbstract
+{
+    protected $_name = "ChechSwapExtensions";
+    protected $_toolName = "grep";
+    protected $_toolCheckCommand = "which grep";
+    protected $_fileFilterRegexp = null; //all files should be checked
+
+    function run(array $files)
+    {
+        foreach ($files as $file) {
+            //check, file is swap?
+            //TODO: add other IDE swap extensions
+            $out = Sys::runCommand("ls -d ${file} | grep -iE '(\.swp|\.swo|\.save|#|~)$'");
+
+            if ($out['exitCode'] == 0) {
+                $out['output'][] = "That '${file}' is swap!";
+                $this->_onRuleFailed($out);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Özellikle Vim kullanırken .swp uzantılı swap dosyaları oluşur. Bunu ve diğer Vim'in oluşturduğu swp dosyalarının commitlenmesini engelledim. Ayrıca Linux'ta genel swap uzantısı olan ~ işaretleri de engelledim.

Diğer IDE'lerde durum nasıl bilmediğim için sadece Vim'e göre yaptım.
